### PR TITLE
Collabora 21.11.3.6.1 plus aliasgroups #10

### DIFF
--- a/charts/collabora-code/Chart.yaml
+++ b/charts/collabora-code/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "6.4.10.10"
+appVersion: "21.11.3.6.1"
 description: A Helm chart for Collabora Office - CODE-Edition
 name: collabora-code
-version: 2.2.1
+version: 2.3.0
 icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
 sources:
 - https://chrisingenhaag.github.io/helm/

--- a/charts/collabora-code/README.md
+++ b/charts/collabora-code/README.md
@@ -60,10 +60,11 @@ The following tables lists the configurable parameters of this chart and their d
 | `replicaCount`                                    | Number of provisioner instances to deployed                   | `1`                                                         |
 | `strategy`                                        | Specifies the strategy used to replace old Pods by new ones   | `Recreate`                                                  |
 | `image.repository`                                | Provisioner image                                             | `collabora/code`                                            |
-| `image.tag`                                       | Version of provisioner image                                  | `4.0.0.2`                                                   |
+| `image.tag`                                       | Version of provisioner image                                  | ``                                                   |
 | `image.pullPolicy`                                | Image pull policy                                             | `IfNotPresent`                                              |
 | `collabora.DONT_GEN_SSL_CERT`                     |                                                               | `true`                                                      |
-| `collabora.domain`                                | Double escaped WOPI host                                      | `wopihost\\.domain`                                         |
+| `collabora.domain`                                | Double escaped WOPI host (DEPRECATED)                         | `wopihost\\.domain`                                         |
+| `collabora.aliasgroups`                           | List of objects containing domain and list of aliases (see values.yaml for exmaple)    | `[]`                                         |
 | `collabora.extra_params`                          | List of params to use as env var                              | `--o:ssl.termination=true --o:ssl.enable=false`             |
 | `collabora.server_name`                           | Collabora server name (single escaped)                        | `collabora\.domain`                                         |
 | `collabora.password`                              | Collabora admin panel pass                                    | `examplepass`                                               |
@@ -101,3 +102,35 @@ The following tables lists the configurable parameters of this chart and their d
 ## Persistence
 
 There is no need for a persistent storage to run collabora code edition. All parameters in `/etc/loolwsd/loolwsd.xml` can be adjusted with using extra_params environment variable.
+
+## Changelog
+
+### Update to 2.3.0
+
+Beginning with Collabora CODE docker image version `21.11.3.6` the definition of domains has changed. The values property `collabora.domain` is now deprecated, but it´s supported for backwards compatibility.
+
+Instead of the old definition
+
+```yaml
+collabora:
+  domain: nextcloud\\.domain
+```
+
+the replacement for this is
+
+```yaml
+collabora:
+  aliasgroups:
+    - domain: https://nextcloud\\.domain:443
+      aliases:
+        - alias1\\.domain
+        - alias2\\.domain
+```
+
+If you already defined a property `collabora.domain` with a value `foo\\.bar` thie will be automatically appended to aliasgroups resulting in the following exampe:
+
+```yaml
+collabora:
+  aliasgroups:
+    - domain: https://foo\\.bar:443
+```

--- a/charts/collabora-code/README.md
+++ b/charts/collabora-code/README.md
@@ -121,7 +121,7 @@ the replacement for this is
 ```yaml
 collabora:
   aliasgroups:
-    - domain: https://nextcloud\\.domain:443
+    - domain: https://nextcloud.domain:443
       aliases:
         - alias1\\.domain
         - alias2\\.domain
@@ -132,5 +132,7 @@ If you already defined a property `collabora.domain` with a value `foo\\.bar` th
 ```yaml
 collabora:
   aliasgroups:
-    - domain: https://foo\\.bar:443
+    - domain: https://foo.bar:443
 ```
+
+Notice that there is noe escaped dot here anymore and we have a protocol and a port. My tests were only successful with such a defintion.

--- a/charts/collabora-code/templates/configmap.yaml
+++ b/charts/collabora-code/templates/configmap.yaml
@@ -1,3 +1,9 @@
+{{ $fullAliasGroups := .Values.collabora.aliasgroups }}
+{{- if .Values.collabora.domain }}
+{{ $deprecatedDomain := dict "domain" (printf "https://%s:443" .Values.collabora.domain) }}
+{{ $fullAliasGroups := append $fullAliasGroups $deprecatedDomain }}
+{{- end }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,6 +11,16 @@ metadata:
 data:
   DONT_GEN_SSL_CERT: "{{ .Values.collabora.DONT_GEN_SSL_CERT }}"
   dictionaries: {{ .Values.collabora.dictionaries }}
-  domain: {{ .Values.collabora.domain }}
+  {{ $counter := 1 }}
+  {{- range $fullAliasGroups }}
+  {{- $alias := .domain }}
+  {{- if .aliases }}
+  {{- $alias := printf "%s,https://%s:443" $alias (join "|" .aliases ) -}}
+  aliasgroup{{ $counter }}: {{ $alias }}
+  {{- else }}
+  aliasgroup{{ $counter }}: {{ $alias }}
+  {{- end }}
+  {{- $counter := add $counter 1 }}
+  {{- end }}
   extra_params: {{ .Values.collabora.extra_params }}
   server_name: {{ .Values.collabora.server_name }}

--- a/charts/collabora-code/templates/configmap.yaml
+++ b/charts/collabora-code/templates/configmap.yaml
@@ -1,8 +1,3 @@
-{{ $fullAliasGroups := .Values.collabora.aliasgroups }}
-{{- if .Values.collabora.domain }}
-{{ $deprecatedDomain := dict "domain" (printf "https://%s:443" .Values.collabora.domain) }}
-{{ $fullAliasGroups := append $fullAliasGroups $deprecatedDomain }}
-{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -11,16 +6,17 @@ metadata:
 data:
   DONT_GEN_SSL_CERT: "{{ .Values.collabora.DONT_GEN_SSL_CERT }}"
   dictionaries: {{ .Values.collabora.dictionaries }}
-  {{ $counter := 1 }}
-  {{- range $fullAliasGroups }}
-  {{- $alias := .domain }}
-  {{- if .aliases }}
-  {{- $alias := printf "%s,https://%s:443" $alias (join "|" .aliases ) -}}
-  aliasgroup{{ $counter }}: {{ $alias }}
+  {{- range $k,$v := .Values.collabora.aliasgroups }}
+  {{- $alias := $v.domain }}
+  {{- if $v.aliases }}
+  {{- $alias := printf "%s,https://%s:443" $alias (join "|" $v.aliases ) }}
+  aliasgroup{{ add $k 1 }}: {{ $alias }}
   {{- else }}
-  aliasgroup{{ $counter }}: {{ $alias }}
+  aliasgroup{{ add $k 1 }}: {{ $alias }}
   {{- end }}
-  {{- $counter := add $counter 1 }}
+  {{- end }}
+  {{- with .Values.collabora.domain }}
+  aliasgroup{{ add (len $.Values.collabora.aliasgroups) 1 }}: {{ printf "https://%s:443" (. | replace "\\" "") }}
   {{- end }}
   extra_params: {{ .Values.collabora.extra_params }}
   server_name: {{ .Values.collabora.server_name }}

--- a/charts/collabora-code/templates/deployment.yaml
+++ b/charts/collabora-code/templates/deployment.yaml
@@ -23,34 +23,12 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "collabora-code.fullname" . }}
           env:
-            - name: DONT_GEN_SSL_CERT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "collabora-code.fullname" . }}
-                  key: DONT_GEN_SSL_CERT
-            - name: dictionaries
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "collabora-code.fullname" . }}
-                  key: dictionaries
-            - name: domain
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "collabora-code.fullname" . }}
-                  key: domain
-            - name: extra_params
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "collabora-code.fullname" . }}
-                  key: extra_params
-            - name: server_name
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "collabora-code.fullname" . }}
-                  key: server_name
             - name: username
               valueFrom:
                 secretKeyRef:

--- a/charts/collabora-code/values.schema.json
+++ b/charts/collabora-code/values.schema.json
@@ -10,7 +10,7 @@
             "replicaCount": 1,
             "image": {
                 "repository": "collabora/code",
-                "tag": "4.0.3.1",
+                "tag": "",
                 "pullPolicy": "IfNotPresent"
             },
             "strategy": "Recreate",
@@ -29,7 +29,11 @@
             },
             "collabora": {
                 "DONT_GEN_SSL_CERT": true,
-                "domain": "nextcloud\\\\.domain",
+                "aliasgroups": [
+                    {
+                        "domain": "https://nextcloud\\\\.domain:443"
+                    }
+                ],
                 "extra_params": "--o:ssl.termination=true --o:ssl.enable=false",
                 "server_name": "collabora\\.domain",
                 "password": "examplepass",
@@ -107,7 +111,7 @@
             "examples": [
                 {
                     "repository": "collabora/code",
-                    "tag": "4.0.3.1",
+                    "tag": "",
                     "pullPolicy": "IfNotPresent"
                 }
             ],
@@ -134,7 +138,7 @@
                     "description": "An explanation about the purpose of this instance.",
                     "default": "",
                     "examples": [
-                        "4.0.3.1"
+                        ""
                     ]
                 },
                 "pullPolicy": {
@@ -319,7 +323,11 @@
             "examples": [
                 {
                     "DONT_GEN_SSL_CERT": true,
-                    "domain": "nextcloud\\\\.domain",
+                    "aliasgroups": [
+                        {
+                            "domain": "https://nextcloud\\\\.domain:443"
+                        }
+                    ],
                     "extra_params": "--o:ssl.termination=true --o:ssl.enable=false",
                     "server_name": "collabora\\.domain",
                     "password": "examplepass",
@@ -329,7 +337,7 @@
             ],
             "required": [
                 "DONT_GEN_SSL_CERT",
-                "domain",
+                "aliasgroups",
                 "extra_params",
                 "server_name",
                 "password",
@@ -347,15 +355,53 @@
                         true
                     ]
                 },
-                "domain": {
-                    "$id": "#/properties/collabora/properties/domain",
-                    "type": "string",
-                    "title": "The domain schema",
+                "aliasgroups": {
+                    "$id": "#/properties/collabora/properties/aliasgroups",
+                    "type": "array",
+                    "title": "The aliasgroups schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": "",
+                    "default": [],
                     "examples": [
-                        "nextcloud\\\\.domain"
-                    ]
+                        [
+                            {
+                                "domain": "https://nextcloud\\\\.domain:443"
+                            }
+                        ]
+                    ],
+                    "additionalItems": true,
+                    "items": {
+                        "$id": "#/properties/collabora/properties/aliasgroups/items",
+                        "anyOf": [
+                            {
+                                "$id": "#/properties/collabora/properties/aliasgroups/items/anyOf/0",
+                                "type": "object",
+                                "title": "The first anyOf schema",
+                                "description": "An explanation about the purpose of this instance.",
+                                "default": {},
+                                "examples": [
+                                    {
+                                        "domain": "https://nextcloud\\\\.domain:443"
+                                    }
+                                ],
+                                "required": [
+                                    "domain"
+                                ],
+                                "properties": {
+                                    "domain": {
+                                        "$id": "#/properties/collabora/properties/aliasgroups/items/anyOf/0/properties/domain",
+                                        "type": "string",
+                                        "title": "The domain schema",
+                                        "description": "An explanation about the purpose of this instance.",
+                                        "default": "",
+                                        "examples": [
+                                            "https://nextcloud\\\\.domain:443"
+                                        ]
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        ]
+                    }
                 },
                 "extra_params": {
                     "$id": "#/properties/collabora/properties/extra_params",

--- a/charts/collabora-code/values.yaml
+++ b/charts/collabora-code/values.yaml
@@ -29,12 +29,13 @@ ingress:
 collabora:
   DONT_GEN_SSL_CERT: true
   # deprecated (for backwards comp, this will be appended to aliasgroups)
-  # domain: nextcloud\\.domain
+  # domain: nextclouddeprecated\\.domain
   aliasgroups: []
-  # - domain: https://nextcloud\\.domain:443
-  #   aliases:
-  #     - alias1\\.domain
-  #     - alias2\\.domain
+  #  - domain: https://nextcloud.domain:443
+  #  - domain: https://nextcloud2.domain:443
+  #    aliases:
+  #      - alias1\\.domain
+  #      - alias2\\.domain
   extra_params: --o:ssl.termination=true --o:ssl.enable=false
   server_name: collabora\.domain
   password: examplepass

--- a/charts/collabora-code/values.yaml
+++ b/charts/collabora-code/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: collabora/code
-  tag: 6.4.14.3
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   pullPolicy: IfNotPresent
 
 strategy: Recreate
@@ -27,7 +28,13 @@ ingress:
 
 collabora:
   DONT_GEN_SSL_CERT: true
-  domain: nextcloud\\.domain
+  # deprecated (for backwards comp, this will be appended to aliasgroups)
+  # domain: nextcloud\\.domain
+  aliasgroups: []
+  # - domain: https://nextcloud\\.domain:443
+  #   aliases:
+  #     - alias1\\.domain
+  #     - alias2\\.domain
   extra_params: --o:ssl.termination=true --o:ssl.enable=false
   server_name: collabora\.domain
   password: examplepass


### PR DESCRIPTION
This closes #10 , updates collabora and adds possibility to use new collabora code env vars. Additionally old property `collabora.domain` is now deprecated in favor of `collabora.aliasgroups` but with backwards compatibiliy to prevent breaking change here.