### PR TITLE
Add existingSecret for admin pannel authentication

### DIFF
--- a/charts/collabora-code/Chart.yaml
+++ b/charts/collabora-code/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "21.11.3.6.1"
 description: A Helm chart for Collabora Office - CODE-Edition
 name: collabora-code
-version: 2.4.3
+version: 2.5.0
 icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
 sources:
 - https://chrisingenhaag.github.io/helm/

--- a/charts/collabora-code/README.md
+++ b/charts/collabora-code/README.md
@@ -55,48 +55,53 @@ $ helm install --name my-release -f values.yaml stable/collabora
 
 The following tables lists the configurable parameters of this chart and their default values.
 
-| Parameter                                         | Description                                                   | Default                                                     |
-| ------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
-| `replicaCount`                                    | Number of provisioner instances to deployed                   | `1`                                                         |
-| `strategy`                                        | Specifies the strategy used to replace old Pods by new ones   | `Recreate`                                                  |
-| `image.repository`                                | Provisioner image                                             | `collabora/code`                                            |
-| `image.tag`                                       | Version of provisioner image                                  | ``                                                   |
-| `image.pullPolicy`                                | Image pull policy                                             | `IfNotPresent`                                              |
-| `collabora.DONT_GEN_SSL_CERT`                     |                                                               | `true`                                                      |
-| `collabora.domain`                                | Double escaped WOPI host (DEPRECATED)                         | `wopihost\\.domain`                                         |
-| `collabora.aliasgroups`                           | List of objects containing domain and list of aliases (see values.yaml for exmaple)    | `[]`                                         |
-| `collabora.extra_params`                          | List of params to use as env var                              | `--o:ssl.termination=true --o:ssl.enable=false`             |
-| `collabora.server_name`                           | Collabora server name (single escaped)                        | `collabora\.domain`                                         |
-| `collabora.password`                              | Collabora admin panel pass                                    | `examplepass`                                               |
-| `collabora.username`                              | Collabora admin panel user                                    | `admin`                                                     |
-| `collabora.dictionaries`                          | Collabora enabled dictionaries                                | `de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru`        |
-| `ingress.enabled`                                 |                                                               | `false`                                                     |
-| `ingress.annotations`                             |                                                               | `{}`                                                        |
-| `ingress.paths`                                   |                                                               | `[]`                                                        |
-| `ingress.hosts`                                   |                                                               | `[]`                                                        |
-| `ingress.tls`                                     |                                                               | `[]`                                                        |
-| `livenessProbe.enabled`                           | Turn on and off liveness probe                                | `true`                                                      |
-| `livenessProbe.initialDelaySeconds`               | Delay before liveness probe is initiated                      | `30`                                                        |
-| `livenessProbe.periodSeconds`                     | How often to perform the probe                                | `10`                                                        |
-| `livenessProbe.timeoutSeconds`                    | When the probe times out                                      | `2`                                                         |
-| `livenessProbe.successThreshold`                  | Minimum consecutive successes for the probe                   | `1`                                                         |
-| `livenessProbe.failureThreshold`                  | Minimum consecutive failures for the probe                    | `3`                                                         |
-| `livenessProbe.scheme`                            | Scheme for the probe                                          | `HTTP`                                                      |
-| `livenessProbe.path`                              | Path for the probe                                            | `/`                                                         |
-| `readinessProbe.enabled`                          | Turn on and off readiness probe                               | `true`                                                      |
-| `readinessProbe.initialDelaySeconds`              | Delay before readiness probe is initiated                     | `30`                                                        |
-| `readinessProbe.periodSeconds`                    | How often to perform the probe                                | `10`                                                        |
-| `readinessProbe.timeoutSeconds`                   | When the probe times out                                      | `2`                                                         |
-| `readinessProbe.successThreshold`                 | Minimum consecutive successes for the probe                   | `1`                                                         |
-| `readinessProbe.failureThreshold`                 | Minimum consecutive failures for the probe                    | `3`                                                         |
-| `readinessProbe.scheme`                           | Scheme for the probe                                          | `HTTP`                                                      |
-| `readinessProbe.path`                             | Path for the probe                                            | `/`                                                         |
-| `securityContext.allowPrivilegeEscalation`        | Create & use Pod Security Policy resources                    | `true`                                                      |
-| `securitycontext.capabilities.add`                | Collabora needs to run with MKNOD as capabibility             | `[MKNOD]`                                                   |
-| `resources`                                       | Resources required (e.g. CPU, memory)                         | `{}`                                                        |
-| `nodeSelector`                                    | Node labels for pod assignment                                | `{}`                                                        |
-| `affinity`                                        | Affinity settings                                             | `{}`                                                        |
-| `tolerations`                                     | List of node taints to tolerate                               | `[]`                                                        |
+| Parameter                                  | Description                                                                                         | Default                                              |
+|--------------------------------------------|-----------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| `replicaCount`                             | Number of provisioner instances to deployed                                                         | `1`                                                  |
+| `strategy`                                 | Specifies the strategy used to replace old Pods by new ones                                         | `Recreate`                                           |
+| `image.repository`                         | Provisioner image                                                                                   | `collabora/code`                                     |
+| `image.tag`                                | Version of provisioner image                                                                        | ``                                                   |
+| `image.pullPolicy`                         | Image pull policy                                                                                   | `IfNotPresent`                                       |
+| `collabora.DONT_GEN_SSL_CERT`              |                                                                                                     | `true`                                               |
+| `collabora.domain`                         | Double escaped WOPI host (DEPRECATED)                                                               | `wopihost\\.domain`                                  |
+| `collabora.aliasgroups`                    | List of objects containing domain and list of aliases (see values.yaml for exmaple)                 | `[]`                                                 |
+| `collabora.extra_params`                   | List of params to use as env var                                                                    | `--o:ssl.termination=true --o:ssl.enable=false`      |
+| `collabora.server_name`                    | Collabora server name (single escaped)                                                              | `collabora\.domain`                                  |
+| `collabora.existingSecret`                 | An existing secret containing the collabora admin panel pass.                                       | {}                                                   |
+| `collabora.existingSecret.enabled`         | Enable the extisting secret. If enabled, *collabora.password* and *collabora.username* are ignored. | `false`                                              |
+| `collabora.existingSecret.secretName`      | Name of the existing secret.                                                                        | ``                                                   |
+| `collabora.existingSecret.usernameKey`     | Key within the secret that contains the username                                                    | `username`                                           |
+| `collabora.existingSecret.passwordKey`     | Key within the secret that contains the password                                                    | `password`                                           |
+| `collabora.password`                       | Collabora admin panel pass                                                                          | `examplepass`                                        |
+| `collabora.username`                       | Collabora admin panel user                                                                          | `admin`                                              |
+| `collabora.dictionaries`                   | Collabora enabled dictionaries                                                                      | `de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru` |
+| `ingress.enabled`                          |                                                                                                     | `false`                                              |
+| `ingress.annotations`                      |                                                                                                     | `{}`                                                 |
+| `ingress.paths`                            |                                                                                                     | `[]`                                                 |
+| `ingress.hosts`                            |                                                                                                     | `[]`                                                 |
+| `ingress.tls`                              |                                                                                                     | `[]`                                                 |
+| `livenessProbe.enabled`                    | Turn on and off liveness probe                                                                      | `true`                                               |
+| `livenessProbe.initialDelaySeconds`        | Delay before liveness probe is initiated                                                            | `30`                                                 |
+| `livenessProbe.periodSeconds`              | How often to perform the probe                                                                      | `10`                                                 |
+| `livenessProbe.timeoutSeconds`             | When the probe times out                                                                            | `2`                                                  |
+| `livenessProbe.successThreshold`           | Minimum consecutive successes for the probe                                                         | `1`                                                  |
+| `livenessProbe.failureThreshold`           | Minimum consecutive failures for the probe                                                          | `3`                                                  |
+| `livenessProbe.scheme`                     | Scheme for the probe                                                                                | `HTTP`                                               |
+| `livenessProbe.path`                       | Path for the probe                                                                                  | `/`                                                  |
+| `readinessProbe.enabled`                   | Turn on and off readiness probe                                                                     | `true`                                               |
+| `readinessProbe.initialDelaySeconds`       | Delay before readiness probe is initiated                                                           | `30`                                                 |
+| `readinessProbe.periodSeconds`             | How often to perform the probe                                                                      | `10`                                                 |
+| `readinessProbe.timeoutSeconds`            | When the probe times out                                                                            | `2`                                                  |
+| `readinessProbe.successThreshold`          | Minimum consecutive successes for the probe                                                         | `1`                                                  |
+| `readinessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                                          | `3`                                                  |
+| `readinessProbe.scheme`                    | Scheme for the probe                                                                                | `HTTP`                                               |
+| `readinessProbe.path`                      | Path for the probe                                                                                  | `/`                                                  |
+| `securityContext.allowPrivilegeEscalation` | Create & use Pod Security Policy resources                                                          | `true`                                               |
+| `securitycontext.capabilities.add`         | Collabora needs to run with MKNOD as capabibility                                                   | `[MKNOD]`                                            |
+| `resources`                                | Resources required (e.g. CPU, memory)                                                               | `{}`                                                 |
+| `nodeSelector`                             | Node labels for pod assignment                                                                      | `{}`                                                 |
+| `affinity`                                 | Affinity settings                                                                                   | `{}`                                                 |
+| `tolerations`                              | List of node taints to tolerate                                                                     | `[]`                                                 |
 
 
 ## Persistence

--- a/charts/collabora-code/templates/deployment.yaml
+++ b/charts/collabora-code/templates/deployment.yaml
@@ -28,13 +28,23 @@ spec:
             - name: username
               valueFrom:
                 secretKeyRef:
+                  {{- if (.Values.collabora.existingSecret).enabled }}
+                  name: {{ .Values.collabora.existingSecret.secretName | quote }}
+                  key: {{ .Values.collabora.existingSecret.usernameKey | quote }}
+                  {{- else }}
                   name: {{ include "collabora-code.fullname" . }}
                   key: username
+                  {{- end }}
             - name: password
               valueFrom:
                 secretKeyRef:
+                  {{- if (.Values.collabora.existingSecret).enabled }}
+                  name: {{ .Values.collabora.existingSecret.secretName | quote }}
+                  key: {{ .Values.collabora.existingSecret.passwordKey | quote }}
+                  {{- else }}
                   name: {{ include "collabora-code.fullname" . }}
                   key: password
+                  {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/collabora-code/templates/secret.yaml
+++ b/charts/collabora-code/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.collabora.existingSecret).enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,5 @@ metadata:
 data:
   username: {{ .Values.collabora.username | b64enc }}
   password: {{ .Values.collabora.password | b64enc }}
+
+{{- end }}

--- a/charts/collabora-code/values.schema.json
+++ b/charts/collabora-code/values.schema.json
@@ -36,6 +36,12 @@
                 ],
                 "extra_params": "--o:ssl.termination=true --o:ssl.enable=false",
                 "server_name": "collabora\\.domain",
+                "existingSecret": {
+                    "enabled": false,
+                    "secretName": "my-secret",
+                    "usernameKey": "username",
+                    "passwordKey": "password"
+                },
                 "password": "examplepass",
                 "username": "admin",
                 "dictionaries": "de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru"

--- a/charts/collabora-code/values.yaml
+++ b/charts/collabora-code/values.yaml
@@ -48,6 +48,11 @@ collabora:
   #      - alias2\\.domain
   extra_params: --o:ssl.termination=true --o:ssl.enable=false
   server_name: collabora\.domain
+  existingSecret:
+    enabled: false
+    secretName: ""
+    usernameKey: "username"
+    passwordKey: "password"
   password: examplepass
   username: admin
   dictionaries: de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru


### PR DESCRIPTION
Hello, I have started using your chart and it worked very well for my home setup with nextcloud.

I wanted to add a small contribution by adding the option to specify the username and password with an existing secret.
This way we can use an external secret operator https://external-secrets.io/v0.5.6/ or manually create secrets without having to commit sensitive values in values.tf

Best regards
Alex

Signed-off-by: Alexander KIRILOV <aleksandar.kirilov@proxym.fr>