### PR TITLE
Add confighash to pod spec

### DIFF
--- a/charts/collabora-code/Chart.yaml
+++ b/charts/collabora-code/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "21.11.3.6.1"
 description: A Helm chart for Collabora Office - CODE-Edition
 name: collabora-code
-version: 2.5.0
+version: 2.5.1
 icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
 sources:
 - https://chrisingenhaag.github.io/helm/

--- a/charts/collabora-code/templates/deployment.yaml
+++ b/charts/collabora-code/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         {{- include "collabora-code.selectorLabels" . | nindent 8 }}
+        confighash: config-{{ .Values.collabora | toYaml | sha256sum | trunc 32 }}
     spec:
       serviceAccountName: {{ include "collabora-code.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
Add sha configmap hash to deployment pod spec to restart pods when upgrade with configmap changes.

This fixes #20 